### PR TITLE
Removing libportal

### DIFF
--- a/com.github.GradienceTeam.Gradience.json
+++ b/com.github.GradienceTeam.Gradience.json
@@ -107,7 +107,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/GradienceTeam/Gradience.git",
-                    "branch": "libportal-removal"
+                    "branch": "libportal-removal",
+                    "commit": "5bcc58c6c8c58578b96291f1356525e99227163c"
                 }
             ]
         }

--- a/com.github.GradienceTeam.Gradience.json
+++ b/com.github.GradienceTeam.Gradience.json
@@ -107,7 +107,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/GradienceTeam/Gradience.git",
-                    "tag": "0.3.1"
+                    "branch": "libportal-removal"
                 }
             ]
         }

--- a/com.github.GradienceTeam.Gradience.json
+++ b/com.github.GradienceTeam.Gradience.json
@@ -100,22 +100,6 @@
             ]
         },
         {
-            "name": "libportal",
-            "buildsystem": "meson",
-            "config-opts": [
-                "-Ddocs=false",
-                "-Dvapi=false",
-                "-Dbackends=gtk4"
-            ],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/flatpak/libportal",
-                    "tag": "0.6"
-                }
-            ]
-        },
-        {
             "name" : "gradience",
             "builddir" : true,
             "buildsystem" : "meson",

--- a/com.github.GradienceTeam.Gradience.json
+++ b/com.github.GradienceTeam.Gradience.json
@@ -108,7 +108,7 @@
                     "type": "git",
                     "url": "https://github.com/GradienceTeam/Gradience.git",
                     "branch": "libportal-removal",
-                    "commit": "5bcc58c6c8c58578b96291f1356525e99227163c"
+                    "commit": "f93d3deaab247ed9b236d81ddbc5bdbcd95e263d"
                 }
             ]
         }


### PR DESCRIPTION
Since the switch to the GNOME 43 runtime, the libportal 0.6 build should no longer be necessary.