### PR TITLE
Add backported Monet Engine hotfix

### DIFF
--- a/com.github.GradienceTeam.Gradience.json
+++ b/com.github.GradienceTeam.Gradience.json
@@ -128,7 +128,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/GradienceTeam/Gradience.git",
-                    "commit": "a8edade954cf683545e9424982f8764f9dcbac79"
+                    "tag": "0.4.1"
                 }
             ]
         }

--- a/com.github.GradienceTeam.Gradience.json
+++ b/com.github.GradienceTeam.Gradience.json
@@ -128,7 +128,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/GradienceTeam/Gradience.git",
-                    "tag": "0.4.0"
+                    "commit": "a8edade954cf683545e9424982f8764f9dcbac79"
                 }
             ]
         }


### PR DESCRIPTION
Add a hotfix from upstream for Monet Engine theme variant menu not working in non-english locales: https://github.com/GradienceTeam/Gradience/commit/a8edade954cf683545e9424982f8764f9dcbac79